### PR TITLE
Simplify input schema definitions

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,11 +1,16 @@
 locals_without_parens = [
   tool: 2,
   tool: 3,
+  tool: 4,
   prompt: 2,
   prompt: 3,
   resource: 2,
   resource: 3,
-  resource: 4
+  resource: 4,
+  input_schema: 1,
+  field: 2,
+  field: 3,
+  field: 4
 ]
 
 [

--- a/lib/phantom/tool.ex
+++ b/lib/phantom/tool.ex
@@ -58,8 +58,8 @@ defmodule Phantom.Tool do
           function: atom(),
           mime_type: String.t(),
           meta: map(),
-          input_schema: JSONSchema.t(),
-          output_schema: JSONSchema.t(),
+          input_schema: JSONSchema.t() | nil,
+          output_schema: JSONSchema.t() | nil,
           annotations: Annotation.t()
         }
 
@@ -188,8 +188,8 @@ defmodule Phantom.Tool do
     %{
       struct!(__MODULE__, attrs)
       | annotations: Annotation.build(annotation_attrs),
-        output_schema: JSONSchema.build(attrs[:output_schema]),
-        input_schema: JSONSchema.build(attrs[:input_schema])
+        input_schema: JSONSchema.build(attrs[:input_schema]),
+        output_schema: JSONSchema.build(attrs[:output_schema])
     }
   end
 

--- a/lib/phantom/tool_json_schema.ex
+++ b/lib/phantom/tool_json_schema.ex
@@ -1,53 +1,747 @@
 defmodule Phantom.Tool.JSONSchema do
   @moduledoc """
-  JSON Schema representing the arguments for the tool, either as `input_schema`
-  or `output_schema`.
+  JSON Schema for tool input and output schemas.
 
-  Learn more at https://json-schema.org/learn/getting-started-step-by-step
+  Provides an Ecto-like DSL for defining input schemas that both generate
+  JSON Schema for clients AND validate/default incoming params at dispatch time.
 
-  Example:
+  ## Standalone usage
 
-      %{
-        type: "object",
-        properties: %{
-          productId: %{
-            description: "The unique identifier for a product",
-            type: "integer"
-          },
-          productName: %{
-            description: "Name of the product",
-            type: "string"
-          }
-        }
-      }
+  Define reusable schemas as modules:
 
+      defmodule MyApp.MCP.Schemas.Filters do
+        use Phantom.Tool.JSONSchema
+
+        input_schema do
+          field :category, :string
+          field :min_price, :number
+        end
+      end
+
+  ## Router usage
+
+      tool :search, description: "Search for stuff" do
+        field :query, :string, required: true
+        field :limit, :integer, default: 10
+        field :tags, {:array, :string}
+      end
+
+  ## Type System
+
+  | DSL type | Elixir guard | JSON Schema type |
+  |----------|-------------|-----------------|
+  | `:string` | `is_binary` | `"string"` |
+  | `:integer` | `is_integer` | `"integer"` |
+  | `:number` | `is_number` | `"number"` |
+  | `:boolean` | `is_boolean` | `"boolean"` |
+  | `{:array, subtype}` | `is_list` + validate each | `"array"` with `items` |
+  | `:map` with `do` block | `is_map` + validate nested | `"object"` with `properties` |
+  | `ModuleName` | delegate to module | delegate to module |
   """
+
   import Phantom.Utils
 
-  @type t :: %__MODULE__{
+  @type field :: %{
+          name: atom(),
+          type: atom() | {:array, atom()} | module(),
           required: boolean(),
+          default: any(),
+          description: String.t() | nil,
+          message: String.t() | nil,
+          validate:
+            (any() -> :ok | {:error, String.t()}) | {module(), atom(), list()} | atom() | nil,
+          enum: list() | nil,
+          minimum: number() | nil,
+          maximum: number() | nil,
+          greater_than: number() | nil,
+          less_than: number() | nil,
+          min_length: non_neg_integer() | nil,
+          max_length: non_neg_integer() | nil,
+          length: non_neg_integer() | nil,
+          pattern: String.t() | nil,
+          exclusion: list() | nil,
+          children: [field()] | nil
+        }
+
+  @type t :: %__MODULE__{
+          required: [String.t()],
           type: String.t(),
-          properties: map()
+          properties: map(),
+          fields: [field()] | nil
         }
 
   @type json :: %{
-          required(:required) => boolean(),
           required(:type) => String.t(),
-          required(:properties) => map()
+          optional(:required) => [String.t()],
+          optional(:properties) => map()
         }
 
-  defstruct required: [], type: "object", properties: %{}
+  defstruct required: [], type: "object", properties: %{}, fields: nil
+
+  @callback __input_schema__() :: t()
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Phantom.Tool.JSONSchema
+      import Phantom.Tool.JSONSchema, only: [input_schema: 1]
+      @before_compile Phantom.Tool.JSONSchema
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    input_schema = Module.get_attribute(env.module, :phantom_input_schema)
+
+    quote do
+      def __input_schema__ do
+        unquote(Macro.escape(input_schema))
+      end
+    end
+  end
+
+  @doc """
+  Define an input schema. Returns a `%JSONSchema{}` struct with validation
+  metadata that is consumed by the following `tool` macro via the
+  `@phantom_input_schema` attribute.
+
+      input_schema do
+        field :query, :string, required: true
+        field :limit, :integer, default: 10
+      end
+
+      tool :search, description: "Search"
+  """
+  defmacro input_schema(do: block) do
+    {defs, fields} = transform_block(block)
+
+    quote do
+      unquote_splicing(defs)
+
+      @phantom_input_schema Phantom.Tool.JSONSchema.build_from_fields(unquote(fields))
+    end
+  end
+
+  @doc false
+  def transform_block({:__block__, _, exprs}) do
+    {fields, defs} =
+      Enum.map_reduce(exprs, [], fn expr, acc ->
+        {field_ast, new_defs} = transform_field(expr)
+        {field_ast, acc ++ new_defs}
+      end)
+
+    {defs, fields}
+  end
+
+  @doc false
+  def transform_block(single_expr) do
+    {field_ast, defs} = transform_field(single_expr)
+    {defs, [field_ast]}
+  end
+
+  @doc false
+  def transform_field({:field, _meta, [name, type]}) do
+    ast =
+      quote do
+        Phantom.Tool.JSONSchema.build_field(unquote(name), unquote(type), [])
+      end
+
+    {ast, []}
+  end
+
+  @doc false
+  def transform_field({:field, meta, [name, type, opts, block_opts]})
+      when is_list(opts) and is_list(block_opts) do
+    transform_field({:field, meta, [name, type, opts ++ block_opts]})
+  end
+
+  @doc false
+  def transform_field({:field, _meta, [name, type, opts]}) when is_list(opts) do
+    {block, opts} = Keyword.pop(opts, :do)
+    {validate_ast, opts} = Keyword.pop(opts, :validate)
+
+    if block do
+      {nested_defs, nested_fields} = transform_block(block)
+
+      field_ast =
+        quote do
+          Phantom.Tool.JSONSchema.build_field(
+            unquote(name),
+            :map,
+            Keyword.put(unquote(opts), :children, unquote(nested_fields))
+          )
+        end
+
+      {field_ast, nested_defs}
+    else
+      build_field_ast(name, type, opts, validate_ast)
+    end
+  end
+
+  @doc false
+  def build_field_ast(name, type, opts, nil) do
+    ast =
+      quote do
+        Phantom.Tool.JSONSchema.build_field(unquote(name), unquote(type), unquote(opts))
+      end
+
+    {ast, []}
+  end
+
+  @doc false
+  def build_field_ast(name, type, opts, validate_ast) do
+    case classify_validator(validate_ast) do
+      :anon_function ->
+        {_, [{:counter, counter} | _], _} = Macro.unique_var(:v, __MODULE__)
+        func_name = :"__phantom_validate_#{counter}__"
+
+        def_ast =
+          quote do
+            @doc false
+            def unquote(func_name)(value), do: unquote(validate_ast).(value)
+          end
+
+        field_ast =
+          quote do
+            Phantom.Tool.JSONSchema.build_field(
+              unquote(name),
+              unquote(type),
+              [{:validate, {__MODULE__, unquote(func_name), []}} | unquote(opts)]
+            )
+          end
+
+        {field_ast, [def_ast]}
+
+      :local_function ->
+        ast =
+          quote do
+            Phantom.Tool.JSONSchema.build_field(
+              unquote(name),
+              unquote(type),
+              [{:validate, {__MODULE__, unquote(validate_ast), []}} | unquote(opts)]
+            )
+          end
+
+        {ast, []}
+
+      :passthrough ->
+        ast =
+          quote do
+            Phantom.Tool.JSONSchema.build_field(
+              unquote(name),
+              unquote(type),
+              [{:validate, unquote(validate_ast)} | unquote(opts)]
+            )
+          end
+
+        {ast, []}
+    end
+  end
+
+  @doc false
+  def classify_validator({:fn, _, _}), do: :anon_function
+  def classify_validator({:&, _, [{:/, _, [{{:., _, _}, _, _}, _]}]}), do: :passthrough
+  def classify_validator({:&, _, _}), do: :anon_function
+  def classify_validator(atom) when is_atom(atom), do: :local_function
+  def classify_validator(_), do: :passthrough
 
   def build(nil), do: nil
+  def build(%__MODULE__{} = schema), do: schema
   def build(attrs), do: struct!(__MODULE__, attrs)
+
+  @doc "Build a `%JSONSchema{}` from a list of field maps, pre-computing JSON Schema properties."
+  def build_from_fields(fields) when is_list(fields) do
+    {properties, required} = fields_to_json_schema(fields)
+
+    %__MODULE__{
+      type: "object",
+      required: required,
+      properties: properties,
+      fields: fields
+    }
+  end
+
+  @doc "Build a field map from name, type, and opts."
+  def build_field(name, type, opts \\ []) do
+    opts = Keyword.new(opts)
+
+    children =
+      case Keyword.get(opts, :children) do
+        nil -> nil
+        %__MODULE__{fields: fields} -> fields
+        list when is_list(list) -> list
+      end
+
+    # Ecto alias: format: ~r// or format: string → pattern:
+    {format, opts} = Keyword.pop(opts, :format)
+
+    pattern =
+      case {Keyword.fetch(opts, :pattern), format} do
+        {{:ok, explicit}, _} -> explicit
+        {:error, %Regex{} = r} -> Regex.source(r)
+        {:error, s} when is_binary(s) -> s
+        {:error, nil} -> nil
+      end
+
+    # Ecto alias: in: → enum:
+    {in_values, opts} = Keyword.pop(opts, :in)
+    enum = Keyword.get(opts, :enum, in_values)
+
+    # Ecto alias: greater_than_or_equal_to: → minimum:
+    {gte, opts} = Keyword.pop(opts, :greater_than_or_equal_to)
+    minimum = Keyword.get(opts, :minimum, gte)
+
+    # Ecto alias: less_than_or_equal_to: → maximum:
+    {lte, opts} = Keyword.pop(opts, :less_than_or_equal_to)
+    maximum = Keyword.get(opts, :maximum, lte)
+
+    %{
+      name: name,
+      type: type,
+      required: Keyword.get(opts, :required, false),
+      default: Keyword.get(opts, :default),
+      description: Keyword.get(opts, :description),
+      message: Keyword.get(opts, :message),
+      validate: Keyword.get(opts, :validate),
+      enum: enum,
+      minimum: minimum,
+      maximum: maximum,
+      greater_than: Keyword.get(opts, :greater_than),
+      less_than: Keyword.get(opts, :less_than),
+      min_length: Keyword.get(opts, :min_length),
+      max_length: Keyword.get(opts, :max_length),
+      length: Keyword.get(opts, :length),
+      pattern: pattern,
+      exclusion: Keyword.get(opts, :exclusion),
+      children: children
+    }
+  end
 
   def to_json(nil), do: %{required: [], type: "object", properties: %{}}
 
-  def to_json(%__MODULE__{} = json_schema) do
+  def to_json(%__MODULE__{} = schema) do
     remove_nils(%{
-      required: json_schema.required,
-      type: json_schema.type,
-      properties: json_schema.properties
+      required: schema.required,
+      type: schema.type,
+      properties: schema.properties
     })
   end
+
+  @doc "Passthrough when no schema is present, or when schema has no DSL fields."
+  def maybe_validate(nil, params), do: {:ok, params}
+  def maybe_validate(%__MODULE__{fields: nil}, params), do: {:ok, params}
+
+  def maybe_validate(%__MODULE__{fields: fields}, params) when is_list(fields),
+    do: validate(fields, params)
+
+  @doc """
+  Validate params against the field definitions. Returns `{:ok, params_with_defaults}`
+  or `{:error, [error_messages]}`.
+  """
+  def validate(schema_or_fields, params, handler \\ nil)
+
+  def validate(%__MODULE__{fields: fields}, params, handler) when is_list(fields),
+    do: validate(fields, params, handler)
+
+  def validate(fields, params, handler) when is_list(fields) do
+    {params, errors} = validate_fields(fields, params, "", handler)
+
+    case errors do
+      [] -> {:ok, params}
+      errors -> {:error, Enum.reverse(errors)}
+    end
+  end
+
+  defp validate_fields(fields, params, prefix, handler) do
+    Enum.reduce(fields, {params, []}, fn field, {params, errors} ->
+      key = to_string(field.name)
+      field_path = if prefix == "", do: key, else: "#{prefix}.#{key}"
+
+      case Map.fetch(params, key) do
+        {:ok, value} ->
+          case validate_field(field, value, field_path, handler) do
+            :ok -> {params, errors}
+            {:error, new_errors} -> {params, new_errors ++ errors}
+          end
+
+        :error ->
+          cond do
+            field.required ->
+              {params, ["Missing required field: #{field_path}" | errors]}
+
+            field.default != nil ->
+              {Map.put(params, key, field.default), errors}
+
+            true ->
+              {params, errors}
+          end
+      end
+    end)
+  end
+
+  defp validate_field(field, value, path, handler) do
+    case do_validate_field(field, value, path, handler) do
+      :ok ->
+        :ok
+
+      {:error, _} when not is_nil(field.message) ->
+        {:error, ["Field #{path}: #{field.message}"]}
+
+      error ->
+        error
+    end
+  end
+
+  defp do_validate_field(field, value, path, handler) do
+    with :ok <- check_type(field.type, value, path, handler) do
+      []
+      |> check_enum(field.enum, value, path)
+      |> check_exclusion(field.exclusion, value, path)
+      |> check_minimum(field.minimum, value, path)
+      |> check_maximum(field.maximum, value, path)
+      |> check_greater_than(field.greater_than, value, path)
+      |> check_less_than(field.less_than, value, path)
+      |> check_length(field.length, value, path)
+      |> check_min_length(field.min_length, value, path)
+      |> check_max_length(field.max_length, value, path)
+      |> check_pattern(field.pattern, value, path)
+      |> check_nested(field, value, path)
+      |> check_validate(field.validate, value, path, handler)
+      |> case do
+        [] -> :ok
+        errors -> {:error, Enum.reverse(errors)}
+      end
+    end
+  end
+
+  defp check_type(:string, value, _path, _handler) when is_binary(value), do: :ok
+
+  defp check_type(:string, value, path, _handler),
+    do: {:error, ["Field #{path}: expected string, got #{inspect(value)}"]}
+
+  defp check_type(:integer, value, _path, _handler) when is_integer(value), do: :ok
+
+  defp check_type(:integer, value, path, _handler),
+    do: {:error, ["Field #{path}: expected integer, got #{inspect(value)}"]}
+
+  defp check_type(:number, value, _path, _handler) when is_number(value), do: :ok
+
+  defp check_type(:number, value, path, _handler),
+    do: {:error, ["Field #{path}: expected number, got #{inspect(value)}"]}
+
+  defp check_type(:boolean, value, _path, _handler) when is_boolean(value), do: :ok
+
+  defp check_type(:boolean, value, path, _handler),
+    do: {:error, ["Field #{path}: expected boolean, got #{inspect(value)}"]}
+
+  defp check_type({:array, subtype}, value, path, handler) when is_list(value) do
+    errors =
+      value
+      |> Enum.with_index()
+      |> Enum.reduce([], fn {elem, idx}, errors ->
+        elem_path = "#{path}[#{idx}]"
+
+        case check_type(subtype, elem, elem_path, handler) do
+          :ok -> errors
+          {:error, new_errors} -> new_errors ++ errors
+        end
+      end)
+
+    case errors do
+      [] -> :ok
+      errors -> {:error, Enum.reverse(errors)}
+    end
+  end
+
+  defp check_type({:array, _subtype}, value, path, _handler),
+    do: {:error, ["Field #{path}: expected array, got #{inspect(value)}"]}
+
+  defp check_type(:map, value, _path, _handler) when is_map(value), do: :ok
+
+  defp check_type(:map, value, path, _handler),
+    do: {:error, ["Field #{path}: expected map, got #{inspect(value)}"]}
+
+  defp check_type(nil, _value, _path, _handler), do: :ok
+
+  defp check_type(module, value, path, handler) when is_atom(module) do
+    if function_exported?(module, :__input_schema__, 0) do
+      schema = module.__input_schema__()
+
+      do_validate_field(
+        build_field(:_, nil, children: schema.fields),
+        value,
+        path,
+        handler
+      )
+    else
+      {:error, ["Field #{path}: unknown type #{inspect(module)}"]}
+    end
+  end
+
+  defp check_enum(errors, nil, _value, _path), do: errors
+
+  defp check_enum(errors, allowed, value, path) do
+    if value in allowed do
+      errors
+    else
+      [
+        "Field #{path}: value #{inspect(value)} not in allowed values: #{inspect(allowed)}"
+        | errors
+      ]
+    end
+  end
+
+  defp check_exclusion(errors, nil, _value, _path), do: errors
+
+  defp check_exclusion(errors, excluded, value, path) do
+    if value in excluded do
+      ["Field #{path}: must not be one of #{inspect(excluded)}" | errors]
+    else
+      errors
+    end
+  end
+
+  defp check_minimum(errors, nil, _value, _path), do: errors
+
+  defp check_minimum(errors, min, value, path) when is_number(value) do
+    if value >= min do
+      errors
+    else
+      ["Field #{path}: value #{inspect(value)} is less than minimum #{min}" | errors]
+    end
+  end
+
+  defp check_minimum(errors, _min, _value, _path), do: errors
+
+  defp check_maximum(errors, nil, _value, _path), do: errors
+
+  defp check_maximum(errors, max, value, path) when is_number(value) do
+    if value <= max do
+      errors
+    else
+      ["Field #{path}: value #{inspect(value)} is greater than maximum #{max}" | errors]
+    end
+  end
+
+  defp check_maximum(errors, _max, _value, _path), do: errors
+
+  defp check_greater_than(errors, nil, _, _), do: errors
+
+  defp check_greater_than(errors, threshold, value, path) when is_number(value) do
+    if value > threshold do
+      errors
+    else
+      ["Field #{path}: must be greater than #{threshold}" | errors]
+    end
+  end
+
+  defp check_greater_than(errors, _, _, _), do: errors
+
+  defp check_less_than(errors, nil, _, _), do: errors
+
+  defp check_less_than(errors, threshold, value, path) when is_number(value) do
+    if value < threshold do
+      errors
+    else
+      ["Field #{path}: must be less than #{threshold}" | errors]
+    end
+  end
+
+  defp check_less_than(errors, _, _, _), do: errors
+
+  defp check_length(errors, nil, _, _), do: errors
+
+  defp check_length(errors, exact, value, path) when is_binary(value) do
+    len = String.length(value)
+
+    if len == exact do
+      errors
+    else
+      ["Field #{path}: length must be exactly #{exact}, got #{len}" | errors]
+    end
+  end
+
+  defp check_length(errors, exact, value, path) when is_list(value) do
+    len = length(value)
+
+    if len == exact do
+      errors
+    else
+      ["Field #{path}: length must be exactly #{exact}, got #{len}" | errors]
+    end
+  end
+
+  defp check_length(errors, _, _, _), do: errors
+
+  defp check_min_length(errors, nil, _value, _path), do: errors
+
+  defp check_min_length(errors, min, value, path) when is_binary(value) do
+    len = String.length(value)
+
+    if len >= min do
+      errors
+    else
+      ["Field #{path}: string length #{len} is less than minimum #{min}" | errors]
+    end
+  end
+
+  defp check_min_length(errors, min, value, path) when is_list(value) do
+    len = length(value)
+
+    if len >= min do
+      errors
+    else
+      ["Field #{path}: length #{len} is less than minimum #{min}" | errors]
+    end
+  end
+
+  defp check_min_length(errors, _min, _value, _path), do: errors
+
+  defp check_max_length(errors, nil, _value, _path), do: errors
+
+  defp check_max_length(errors, max, value, path) when is_binary(value) do
+    len = String.length(value)
+
+    if len <= max do
+      errors
+    else
+      ["Field #{path}: string length #{len} is greater than maximum #{max}" | errors]
+    end
+  end
+
+  defp check_max_length(errors, max, value, path) when is_list(value) do
+    len = length(value)
+
+    if len <= max do
+      errors
+    else
+      ["Field #{path}: length #{len} is greater than maximum #{max}" | errors]
+    end
+  end
+
+  defp check_max_length(errors, _max, _value, _path), do: errors
+
+  defp check_pattern(errors, nil, _value, _path), do: errors
+
+  defp check_pattern(errors, pattern, value, path) when is_binary(value) do
+    case Regex.compile(pattern) do
+      {:ok, regex} ->
+        if Regex.match?(regex, value) do
+          errors
+        else
+          ["Field #{path}: value does not match pattern #{pattern}" | errors]
+        end
+
+      _ ->
+        errors
+    end
+  end
+
+  defp check_pattern(errors, _pattern, _value, _path), do: errors
+
+  defp check_nested(errors, %{children: children}, value, path)
+       when is_list(children) and is_map(value) do
+    {_params, nested_errors} = validate_fields(children, value, path, nil)
+    nested_errors ++ errors
+  end
+
+  defp check_nested(errors, _field, _value, _path), do: errors
+
+  defp check_validate(errors, nil, _value, _path, _handler), do: errors
+
+  defp check_validate(errors, fun, value, path, _handler) when is_function(fun, 1) do
+    case fun.(value) do
+      :ok -> errors
+      {:error, reason} -> ["Field #{path}: #{reason}" | errors]
+    end
+  end
+
+  defp check_validate(errors, {m, f, a}, value, path, _handler) do
+    case apply(m, f, [value | a]) do
+      :ok -> errors
+      {:error, reason} -> ["Field #{path}: #{reason}" | errors]
+    end
+  end
+
+  defp check_validate(errors, atom, value, path, handler)
+       when is_atom(atom) and not is_nil(handler) do
+    case apply(handler, atom, [value]) do
+      :ok -> errors
+      {:error, reason} -> ["Field #{path}: #{reason}" | errors]
+    end
+  end
+
+  defp check_validate(errors, _atom, _value, _path, _handler), do: errors
+
+  defp fields_to_json_schema(fields) do
+    Enum.reduce(fields, {%{}, []}, fn field, {props, required} ->
+      prop = field_to_json_property(field)
+      props = Map.put(props, field.name, prop)
+
+      required =
+        if field.required do
+          required ++ [to_string(field.name)]
+        else
+          required
+        end
+
+      {props, required}
+    end)
+  end
+
+  defp field_to_json_property(field) do
+    base = type_to_json(field.type, field)
+
+    base
+    |> maybe_put(:description, field.description)
+    |> maybe_put(:enum, field.enum)
+    |> maybe_put(:minimum, field.minimum)
+    |> maybe_put(:maximum, field.maximum)
+    |> maybe_put(:exclusiveMinimum, field.greater_than)
+    |> maybe_put(:exclusiveMaximum, field.less_than)
+    |> put_length_constraints(field)
+    |> maybe_put(:pattern, field.pattern)
+  end
+
+  defp put_length_constraints(json, field) do
+    case field.type do
+      {:array, _} ->
+        json
+        |> maybe_put(:minItems, field.length || field.min_length)
+        |> maybe_put(:maxItems, field.length || field.max_length)
+
+      _ ->
+        json
+        |> maybe_put(:minLength, field.length || field.min_length)
+        |> maybe_put(:maxLength, field.length || field.max_length)
+    end
+  end
+
+  defp type_to_json(:string, _field), do: %{type: "string"}
+  defp type_to_json(:integer, _field), do: %{type: "integer"}
+  defp type_to_json(:number, _field), do: %{type: "number"}
+  defp type_to_json(:boolean, _field), do: %{type: "boolean"}
+
+  defp type_to_json({:array, subtype}, _field) do
+    %{type: "array", items: type_to_json(subtype, nil)}
+  end
+
+  defp type_to_json(:map, %{children: children}) when is_list(children) do
+    {properties, required} = fields_to_json_schema(children)
+    result = %{type: "object", properties: properties}
+    if required == [], do: result, else: Map.put(result, :required, required)
+  end
+
+  defp type_to_json(:map, _field), do: %{type: "object"}
+
+  defp type_to_json(module, _field) when is_atom(module) do
+    if function_exported?(module, :__input_schema__, 0) do
+      schema = module.__input_schema__()
+      to_json(schema)
+    else
+      %{type: "object"}
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, []), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/test/phantom/input_schema_test.exs
+++ b/test/phantom/input_schema_test.exs
@@ -1,0 +1,1214 @@
+defmodule Phantom.Tool.JSONSchemaTest do
+  use ExUnit.Case
+
+  alias Phantom.Tool.JSONSchema
+
+  describe "build_from_fields/1" do
+    test "builds schema from field list" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:query, :string, required: true),
+          JSONSchema.build_field(:limit, :integer, default: 10)
+        ])
+
+      assert %JSONSchema{fields: fields} = schema
+      assert length(fields) == 2
+
+      query = Enum.find(fields, &(&1.name == :query))
+      assert query.type == :string
+      assert query.required == true
+
+      limit = Enum.find(fields, &(&1.name == :limit))
+      assert limit.type == :integer
+      assert limit.default == 10
+    end
+  end
+
+  describe "build_field/3" do
+    test "builds a field with defaults" do
+      field = JSONSchema.build_field(:name, :string, [])
+      assert field.name == :name
+      assert field.type == :string
+      assert field.required == false
+      assert field.default == nil
+      assert field.validate == nil
+      assert field.enum == nil
+      assert field.children == nil
+    end
+
+    test "builds a field with all options" do
+      field =
+        JSONSchema.build_field(:count, :integer,
+          required: true,
+          default: 5,
+          description: "The count",
+          enum: [1, 5, 10],
+          minimum: 1,
+          maximum: 10
+        )
+
+      assert field.name == :count
+      assert field.type == :integer
+      assert field.required == true
+      assert field.default == 5
+      assert field.description == "The count"
+      assert field.enum == [1, 5, 10]
+      assert field.minimum == 1
+      assert field.maximum == 10
+    end
+
+    test "builds a field with string constraints" do
+      field =
+        JSONSchema.build_field(:email, :string,
+          min_length: 5,
+          max_length: 100,
+          pattern: "^[^@]+@[^@]+$"
+        )
+
+      assert field.min_length == 5
+      assert field.max_length == 100
+      assert field.pattern == "^[^@]+@[^@]+$"
+    end
+
+    test "builds an array field" do
+      field = JSONSchema.build_field(:tags, {:array, :string}, [])
+      assert field.type == {:array, :string}
+    end
+
+    test "builds a map field with children" do
+      children =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:category, :string, []),
+          JSONSchema.build_field(:min_price, :number, [])
+        ])
+
+      field = JSONSchema.build_field(:filters, :map, children: children)
+      assert field.type == :map
+      assert is_list(field.children)
+      assert length(field.children) == 2
+    end
+  end
+
+  describe "to_json/1" do
+    test "converts flat schema to JSON Schema" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:query, :string, required: true, description: "Search query"),
+          JSONSchema.build_field(:limit, :integer, default: 10, description: "Max results")
+        ])
+
+      json = JSONSchema.to_json(schema)
+
+      assert json.type == "object"
+      assert json.required == ["query"]
+      assert json.properties.query == %{type: "string", description: "Search query"}
+      assert json.properties.limit == %{type: "integer", description: "Max results"}
+    end
+
+    test "converts array type to JSON Schema" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:tags, {:array, :string}, description: "Tags list")
+        ])
+
+      json = JSONSchema.to_json(schema)
+
+      assert json.properties.tags == %{
+               type: "array",
+               items: %{type: "string"},
+               description: "Tags list"
+             }
+    end
+
+    test "converts nested map to JSON Schema" do
+      children =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:category, :string, description: "Category filter"),
+          JSONSchema.build_field(:min_price, :number, required: true)
+        ])
+
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:filters, :map, required: true, children: children)
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.required == ["filters"]
+
+      filters_prop = json.properties.filters
+      assert filters_prop.type == "object"
+      assert filters_prop.required == ["min_price"]
+      assert filters_prop.properties.category == %{type: "string", description: "Category filter"}
+      assert filters_prop.properties.min_price == %{type: "number"}
+    end
+
+    test "includes enum constraint in JSON Schema" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:status, :string, enum: ["active", "inactive"])
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.status == %{type: "string", enum: ["active", "inactive"]}
+    end
+
+    test "includes numeric constraints in JSON Schema" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:count, :integer, minimum: 1, maximum: 100)
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.count == %{type: "integer", minimum: 1, maximum: 100}
+    end
+
+    test "includes string constraints in JSON Schema" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:name, :string,
+            min_length: 1,
+            max_length: 50,
+            pattern: "^[a-z]+$"
+          )
+        ])
+
+      json = JSONSchema.to_json(schema)
+
+      assert json.properties.name == %{
+               type: "string",
+               minLength: 1,
+               maxLength: 50,
+               pattern: "^[a-z]+$"
+             }
+    end
+
+    test "converts array of integers" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:ids, {:array, :integer}, [])
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.ids == %{type: "array", items: %{type: "integer"}}
+    end
+  end
+
+  describe "validate/2" do
+    test "passes valid params" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:query, :string, required: true),
+          JSONSchema.build_field(:limit, :integer, [])
+        ])
+
+      assert {:ok, %{"query" => "hello", "limit" => 5}} =
+               JSONSchema.validate(schema, %{"query" => "hello", "limit" => 5})
+    end
+
+    test "errors on missing required field" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:query, :string, required: true)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{})
+      assert "Missing required field: query" in errors
+    end
+
+    test "applies defaults for missing optional fields" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:limit, :integer, default: 10),
+          JSONSchema.build_field(:offset, :integer, default: 0)
+        ])
+
+      assert {:ok, params} = JSONSchema.validate(schema, %{})
+      assert params["limit"] == 10
+      assert params["offset"] == 0
+    end
+
+    test "does not overwrite provided values with defaults" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:limit, :integer, default: 10)
+        ])
+
+      assert {:ok, params} = JSONSchema.validate(schema, %{"limit" => 25})
+      assert params["limit"] == 25
+    end
+
+    test "validates string type" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:name, :string, required: true)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"name" => 123})
+      assert "Field name: expected string, got 123" in errors
+    end
+
+    test "validates integer type" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:count, :integer, required: true)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"count" => "abc"})
+      assert "Field count: expected integer, got \"abc\"" in errors
+
+      # floats are not integers
+      assert {:error, errors} = JSONSchema.validate(schema, %{"count" => 1.5})
+      assert "Field count: expected integer, got 1.5" in errors
+    end
+
+    test "validates number type" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:price, :number, required: true)
+        ])
+
+      # integers are valid numbers
+      assert {:ok, _} = JSONSchema.validate(schema, %{"price" => 10})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"price" => 10.5})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"price" => "abc"})
+      assert "Field price: expected number, got \"abc\"" in errors
+    end
+
+    test "validates boolean type" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:active, :boolean, required: true)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"active" => true})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"active" => false})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"active" => "yes"})
+      assert "Field active: expected boolean, got \"yes\"" in errors
+    end
+
+    test "validates {:array, :string} - all elements must be strings" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:tags, {:array, :string}, required: true)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"tags" => ["a", "b", "c"]})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"tags" => ["a", 42, "c"]})
+      assert "Field tags[1]: expected string, got 42" in errors
+    end
+
+    test "validates {:array, :integer} - rejects string elements" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:ids, {:array, :integer}, required: true)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"ids" => [1, 2, 3]})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"ids" => [1, "two", 3]})
+      assert "Field ids[1]: expected integer, got \"two\"" in errors
+    end
+
+    test "validates array type - must be a list" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:tags, {:array, :string}, required: true)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"tags" => "not a list"})
+      assert "Field tags: expected array, got \"not a list\"" in errors
+    end
+
+    test "validates :map with children recursively" do
+      children =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:category, :string, required: true),
+          JSONSchema.build_field(:min_price, :number, [])
+        ])
+
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:filters, :map, required: true, children: children)
+        ])
+
+      # valid
+      assert {:ok, _} =
+               JSONSchema.validate(schema, %{
+                 "filters" => %{"category" => "books", "min_price" => 9.99}
+               })
+
+      # missing nested required field
+      assert {:error, errors} =
+               JSONSchema.validate(schema, %{"filters" => %{"min_price" => 9.99}})
+
+      assert "Missing required field: filters.category" in errors
+
+      # wrong nested type
+      assert {:error, errors} =
+               JSONSchema.validate(schema, %{
+                 "filters" => %{"category" => 123, "min_price" => 9.99}
+               })
+
+      assert "Field filters.category: expected string, got 123" in errors
+    end
+
+    test "validates map type - must be a map" do
+      children =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:x, :string, [])
+        ])
+
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:data, :map, required: true, children: children)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"data" => "not a map"})
+      assert "Field data: expected map, got \"not a map\"" in errors
+    end
+
+    test "validates module-ref type delegates to module's schema" do
+      # We'll define a simple test module inline
+      defmodule TestNestedSchema do
+        @moduledoc false
+        def __input_schema__ do
+          JSONSchema.build_from_fields([
+            JSONSchema.build_field(:x, :integer, required: true),
+            JSONSchema.build_field(:y, :integer, required: true)
+          ])
+        end
+      end
+
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:point, TestNestedSchema, required: true)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"point" => %{"x" => 1, "y" => 2}})
+
+      assert {:error, errors} =
+               JSONSchema.validate(schema, %{"point" => %{"x" => 1}})
+
+      assert "Missing required field: point.y" in errors
+    end
+
+    test "collects multiple errors" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:name, :string, required: true),
+          JSONSchema.build_field(:age, :integer, required: true),
+          JSONSchema.build_field(:active, :boolean, required: true)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{})
+      assert length(errors) == 3
+      assert "Missing required field: name" in errors
+      assert "Missing required field: age" in errors
+      assert "Missing required field: active" in errors
+    end
+
+    test "enum constraint" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:status, :string,
+            required: true,
+            enum: ["active", "inactive"]
+          )
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"status" => "active"})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"status" => "deleted"})
+
+      assert "Field status: value \"deleted\" not in allowed values: [\"active\", \"inactive\"]" in errors
+    end
+
+    test "minimum/maximum constraint" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:count, :integer, required: true, minimum: 1, maximum: 100)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"count" => 50})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"count" => 1})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"count" => 100})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"count" => 0})
+      assert "Field count: value 0 is less than minimum 1" in errors
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"count" => 101})
+      assert "Field count: value 101 is greater than maximum 100" in errors
+    end
+
+    test "min_length/max_length constraint" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:name, :string, required: true, min_length: 2, max_length: 10)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"name" => "hi"})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"name" => "x"})
+      assert "Field name: string length 1 is less than minimum 2" in errors
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"name" => "this is way too long"})
+      assert "Field name: string length 20 is greater than maximum 10" in errors
+    end
+
+    test "pattern constraint" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:code, :string, required: true, pattern: "^[A-Z]{3}$")
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"code" => "ABC"})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"code" => "abc"})
+      assert "Field code: value does not match pattern ^[A-Z]{3}$" in errors
+    end
+
+    test "custom validate: fn called and error propagated" do
+      validator = fn value ->
+        if String.starts_with?(value, "q:"), do: :ok, else: {:error, "must start with q:"}
+      end
+
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:query, :string, required: true, validate: validator)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"query" => "q:hello"})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"query" => "hello"})
+      assert "Field query: must start with q:" in errors
+    end
+
+    test "custom validate: with {m,f,a} tuple" do
+      defmodule TestValidator do
+        @moduledoc false
+        def validate_range(value, min, max) do
+          if value >= min and value <= max, do: :ok, else: {:error, "out of range"}
+        end
+      end
+
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:score, :integer,
+            required: true,
+            validate: {TestValidator, :validate_range, [1, 10]}
+          )
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"score" => 5})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"score" => 15})
+      assert "Field score: out of range" in errors
+    end
+
+    test "custom validate: with atom resolves to handler module" do
+      defmodule TestHandlerModule do
+        @moduledoc false
+        def validate_query(value) do
+          if String.length(value) > 0, do: :ok, else: {:error, "must not be empty"}
+        end
+      end
+
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:query, :string,
+            required: true,
+            validate: :validate_query
+          )
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"query" => "hello"}, TestHandlerModule)
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"query" => ""}, TestHandlerModule)
+      assert "Field query: must not be empty" in errors
+    end
+  end
+
+  describe "maybe_validate/2" do
+    test "passthrough when schema is nil" do
+      assert {:ok, %{"foo" => "bar"}} = JSONSchema.maybe_validate(nil, %{"foo" => "bar"})
+    end
+
+    test "validates when schema is present" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:query, :string, required: true)
+        ])
+
+      assert {:ok, _} = JSONSchema.maybe_validate(schema, %{"query" => "hello"})
+      assert {:error, _} = JSONSchema.maybe_validate(schema, %{})
+    end
+  end
+
+  describe "DSL macros" do
+    test "inline do-block field macros compile tool with input schema" do
+      defmodule DSLTestRouter do
+        use Phantom.Router,
+          name: "DSLTest",
+          vsn: "1.0"
+
+        tool :search_tool, description: "Search for stuff" do
+          field :query, :string, required: true, description: "Search query"
+          field :limit, :integer, default: 10
+          field :category, :string, enum: ["science", "math"]
+          field :tags, {:array, :string}
+        end
+
+        def search_tool(params, session) do
+          {:reply, Phantom.Tool.text(params["query"]), session}
+        end
+      end
+
+      info = DSLTestRouter.__phantom__(:info)
+      tool = Enum.find(info.tools, &(&1.name == "search_tool"))
+
+      assert tool != nil
+      assert %JSONSchema{} = tool.input_schema
+
+      # Verify JSON Schema was generated
+      json = JSONSchema.to_json(tool.input_schema)
+      assert json.required == ["query"]
+      assert json.properties.query == %{type: "string", description: "Search query"}
+      assert json.properties.limit == %{type: "integer"}
+      assert json.properties.category == %{type: "string", enum: ["science", "math"]}
+      assert json.properties.tags == %{type: "array", items: %{type: "string"}}
+
+      # Verify fields were stored
+      assert length(tool.input_schema.fields) == 4
+    end
+
+    test "inline nested field :x, :map do...end compiles correctly" do
+      defmodule NestedDSLTestRouter do
+        use Phantom.Router,
+          name: "NestedDSLTest",
+          vsn: "1.0"
+
+        tool :nested_search_tool, description: "Search with filters" do
+          field :query, :string, required: true
+
+          field :filters, :map, required: true do
+            field :category, :string
+            field :min_price, :number
+          end
+        end
+
+        def nested_search_tool(params, session) do
+          {:reply, Phantom.Tool.text(params["query"]), session}
+        end
+      end
+
+      info = NestedDSLTestRouter.__phantom__(:info)
+      tool = Enum.find(info.tools, &(&1.name == "nested_search_tool"))
+
+      assert %JSONSchema{} = tool.input_schema
+      filters_field = Enum.find(tool.input_schema.fields, &(&1.name == :filters))
+      assert filters_field.type == :map
+      assert is_list(filters_field.children)
+      assert length(filters_field.children) == 2
+
+      # Verify JSON Schema nested structure
+      json = JSONSchema.to_json(tool.input_schema)
+      assert json.properties.filters.type == "object"
+      assert json.properties.filters.properties.category == %{type: "string"}
+      assert json.properties.filters.properties.min_price == %{type: "number"}
+    end
+
+    test "module-reference field compiles correctly" do
+      defmodule SharedSchema do
+        use Phantom.Tool.JSONSchema
+
+        input_schema do
+          field :category, :string, required: true
+          field :min_price, :number
+        end
+      end
+
+      defmodule ModRefDSLTestRouter do
+        use Phantom.Router,
+          name: "ModRefDSLTest",
+          vsn: "1.0"
+
+        tool :modref_search_tool, description: "Search with shared filters" do
+          field :query, :string, required: true
+          field :filters, SharedSchema, required: true
+        end
+
+        def modref_search_tool(params, session) do
+          {:reply, Phantom.Tool.text(params["query"]), session}
+        end
+      end
+
+      info = ModRefDSLTestRouter.__phantom__(:info)
+      tool = Enum.find(info.tools, &(&1.name == "modref_search_tool"))
+
+      filters_field = Enum.find(tool.input_schema.fields, &(&1.name == :filters))
+      assert filters_field.type == SharedSchema
+
+      # JSON Schema should expand the module's schema
+      json = JSONSchema.to_json(tool.input_schema)
+      assert json.properties.filters.type == "object"
+      assert json.properties.filters.required == ["category"]
+      assert json.properties.filters.properties.category == %{type: "string"}
+    end
+
+    test "use Phantom.Tool.JSONSchema standalone module defines __input_schema__/0" do
+      defmodule StandaloneSchema do
+        use Phantom.Tool.JSONSchema
+
+        input_schema do
+          field :name, :string, required: true
+          field :age, :integer
+        end
+      end
+
+      schema = StandaloneSchema.__input_schema__()
+      assert %JSONSchema{} = schema
+      assert length(schema.fields) == 2
+
+      name_field = Enum.find(schema.fields, &(&1.name == :name))
+      assert name_field.required == true
+      assert name_field.type == :string
+    end
+
+    test "validate: :atom resolves to local function in standalone module" do
+      defmodule StandaloneWithValidator do
+        use Phantom.Tool.JSONSchema
+
+        input_schema do
+          field :email, :string, required: true, validate: :validate_email
+        end
+
+        def validate_email(value) do
+          if String.contains?(value, "@"), do: :ok, else: {:error, "must contain @"}
+        end
+      end
+
+      schema = StandaloneWithValidator.__input_schema__()
+
+      # Works without a handler argument — the atom was resolved to {Module, :fun, []} at compile time
+      assert {:ok, _} = JSONSchema.validate(schema, %{"email" => "a@b.com"})
+      assert {:error, errors} = JSONSchema.validate(schema, %{"email" => "nope"})
+      assert Enum.any?(errors, &String.contains?(&1, "must contain @"))
+    end
+
+    test "validate: :atom resolves to local function in router" do
+      defmodule RouterWithValidator do
+        use Phantom.Router,
+          name: "RouterValidator",
+          vsn: "1.0"
+
+        tool :validated_tool, description: "Test" do
+          field :email, :string, required: true, validate: :validate_email
+        end
+
+        def validated_tool(params, session) do
+          {:reply, Phantom.Tool.text(params["email"]), session}
+        end
+
+        def validate_email(value) do
+          if String.contains?(value, "@"), do: :ok, else: {:error, "must contain @"}
+        end
+      end
+
+      info = RouterWithValidator.__phantom__(:info)
+      tool = Enum.find(info.tools, &(&1.name == "validated_tool"))
+      schema = tool.input_schema
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"email" => "a@b.com"})
+      assert {:error, errors} = JSONSchema.validate(schema, %{"email" => "nope"})
+      assert Enum.any?(errors, &String.contains?(&1, "must contain @"))
+    end
+
+    test "tools/list JSON output has correct shape for DSL-defined tool" do
+      defmodule JSONOutputRouter do
+        use Phantom.Router,
+          name: "JSONOutputTest",
+          vsn: "1.0"
+
+        tool :json_test_tool, description: "A test tool" do
+          field :message, :string, required: true, description: "Message"
+          field :count, :integer, default: 1
+        end
+
+        def json_test_tool(params, session) do
+          {:reply, Phantom.Tool.text(params["message"]), session}
+        end
+      end
+
+      info = JSONOutputRouter.__phantom__(:info)
+      tool = Enum.find(info.tools, &(&1.name == "json_test_tool"))
+      json = Phantom.Tool.to_json(tool)
+
+      assert json.name == "json_test_tool"
+      assert json.description == "A test tool"
+      assert json.inputSchema.required == ["message"]
+      assert json.inputSchema.type == "object"
+      assert json.inputSchema.properties.message == %{type: "string", description: "Message"}
+      assert json.inputSchema.properties.count == %{type: "integer"}
+    end
+
+    test "tool without input_schema still works (backwards compatible)" do
+      defmodule NoSchemaRouter do
+        use Phantom.Router,
+          name: "NoSchemaTest",
+          vsn: "1.0"
+
+        tool :simple_tool, description: "No schema"
+
+        def simple_tool(_params, session) do
+          {:reply, Phantom.Tool.text("ok"), session}
+        end
+      end
+
+      info = NoSchemaRouter.__phantom__(:info)
+      tool = Enum.find(info.tools, &(&1.name == "simple_tool"))
+      assert tool.input_schema == nil
+    end
+
+    test "raw map input_schema still works (backwards compatible)" do
+      defmodule RawMapRouter do
+        use Phantom.Router,
+          name: "RawMapTest",
+          vsn: "1.0"
+
+        tool :raw_tool,
+          description: "Raw schema",
+          input_schema: %{
+            required: [:message],
+            properties: %{
+              message: %{type: "string"}
+            }
+          }
+
+        def raw_tool(params, session) do
+          {:reply, Phantom.Tool.text(params["message"]), session}
+        end
+      end
+
+      info = RawMapRouter.__phantom__(:info)
+      tool = Enum.find(info.tools, &(&1.name == "raw_tool"))
+
+      assert %{required: [:message], properties: %{message: %{type: "string"}}} =
+               tool.input_schema
+    end
+  end
+
+  describe "dispatch-time validation" do
+    import Phantom.TestDispatcher
+
+    setup do
+      start_supervised({Phoenix.PubSub, name: Test.PubSub})
+      start_supervised({Phantom.Tracker, [name: Phantom.Tracker, pubsub_server: Test.PubSub]})
+      Phantom.Cache.register(Test.MCP.Router)
+      :ok
+    end
+
+    test "tools/call with valid params succeeds" do
+      request_tool("validated_echo_tool", %{"message" => "hello", "count" => 2}, [])
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+      assert %{jsonrpc: "2.0", id: 1, result: %{content: [%{type: "text"}]}} = response
+    end
+
+    test "tools/call with missing required param returns -32602" do
+      request_tool("validated_echo_tool", %{}, [])
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+
+      assert %{
+               jsonrpc: "2.0",
+               id: 1,
+               error: %{
+                 code: -32602,
+                 message: "Invalid Params",
+                 data: %{validation_errors: errors}
+               }
+             } = response
+
+      assert "Missing required field: message" in errors
+    end
+
+    test "tools/call with wrong type returns -32602" do
+      request_tool("validated_echo_tool", %{"message" => 123}, [])
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+
+      assert %{
+               jsonrpc: "2.0",
+               id: 1,
+               error: %{
+                 code: -32602,
+                 data: %{validation_errors: errors}
+               }
+             } = response
+
+      assert "Field message: expected string, got 123" in errors
+    end
+
+    test "tools/call applies defaults before calling handler" do
+      request_tool("validated_echo_tool", %{"message" => "hello"}, [])
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+      # The handler should receive count=1 as default
+      result = response.result
+      text = hd(result.content).text
+      # The validated_echo_tool will echo back its params as JSON
+      decoded = JSON.decode!(text)
+      assert decoded["count"] == 1
+    end
+
+    test "tools/call with invalid array element returns -32602" do
+      request_tool("validated_echo_tool", %{"message" => "hello", "tags" => ["a", 42]}, [])
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+
+      assert %{
+               jsonrpc: "2.0",
+               id: 1,
+               error: %{
+                 code: -32602,
+                 data: %{validation_errors: errors}
+               }
+             } = response
+
+      assert "Field tags[1]: expected string, got 42" in errors
+    end
+
+    test "tools/call with invalid nested map field returns -32602" do
+      request_tool(
+        "validated_nested_tool",
+        %{"query" => "hello", "filters" => %{"min_price" => "not a number"}},
+        []
+      )
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+
+      assert %{
+               jsonrpc: "2.0",
+               id: 1,
+               error: %{
+                 code: -32602,
+                 data: %{validation_errors: errors}
+               }
+             } = response
+
+      assert Enum.any?(errors, &String.contains?(&1, "filters.min_price"))
+    end
+
+    test "tools/call with custom validator rejection returns -32602" do
+      request_tool("validated_custom_tool", %{"query" => "ab"}, [])
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+
+      assert %{
+               jsonrpc: "2.0",
+               id: 1,
+               error: %{
+                 code: -32602,
+                 data: %{validation_errors: errors}
+               }
+             } = response
+
+      assert Enum.any?(errors, &String.contains?(&1, "query"))
+    end
+
+    test "tools/call with raw-map input_schema does NOT validate (backwards compatible)" do
+      # echo_tool uses raw map input_schema, should pass through without validation
+      request_tool("echo_tool", %{"message" => 12345}, [])
+
+      assert_receive {:conn, conn}
+      assert conn.status == 200
+
+      assert_receive {:response, 1, "message", response}
+      # Should succeed even with wrong type - raw map schemas don't validate
+      assert %{jsonrpc: "2.0", id: 1, result: %{content: _}} = response
+    end
+  end
+
+  describe "Ecto-style aliases in build_field/3" do
+    test "greater_than_or_equal_to: aliases to minimum:" do
+      field = JSONSchema.build_field(:count, :integer, greater_than_or_equal_to: 1)
+      assert field.minimum == 1
+
+      # Direct minimum: still works
+      field2 = JSONSchema.build_field(:count, :integer, minimum: 1)
+      assert field2.minimum == 1
+
+      # Explicit minimum: wins over alias
+      field3 = JSONSchema.build_field(:count, :integer, minimum: 5, greater_than_or_equal_to: 1)
+      assert field3.minimum == 5
+    end
+
+    test "less_than_or_equal_to: aliases to maximum:" do
+      field = JSONSchema.build_field(:count, :integer, less_than_or_equal_to: 100)
+      assert field.maximum == 100
+
+      # Explicit maximum: wins over alias
+      field2 = JSONSchema.build_field(:count, :integer, maximum: 50, less_than_or_equal_to: 100)
+      assert field2.maximum == 50
+    end
+
+    test "explicit minimum: 0 is not overridden by alias" do
+      field = JSONSchema.build_field(:count, :integer, minimum: 0, greater_than_or_equal_to: 5)
+      assert field.minimum == 0
+
+      field2 = JSONSchema.build_field(:count, :integer, maximum: 0, less_than_or_equal_to: 10)
+      assert field2.maximum == 0
+    end
+
+    test "in: aliases to enum:" do
+      field = JSONSchema.build_field(:status, :string, in: ["active", "inactive"])
+      assert field.enum == ["active", "inactive"]
+
+      # Explicit enum: wins over alias
+      field2 = JSONSchema.build_field(:status, :string, enum: ["a"], in: ["a", "b"])
+      assert field2.enum == ["a"]
+    end
+
+    test "format: ~r// aliases to pattern: string" do
+      field = JSONSchema.build_field(:email, :string, format: ~r/@/)
+      assert field.pattern == "@"
+
+      # format: as string also works
+      field2 = JSONSchema.build_field(:email, :string, format: "^[^@]+@")
+      assert field2.pattern == "^[^@]+@"
+
+      # Explicit pattern: wins over format:
+      field3 = JSONSchema.build_field(:email, :string, pattern: "^x$", format: ~r/@/)
+      assert field3.pattern == "^x$"
+    end
+  end
+
+  describe "exclusive bounds (greater_than/less_than)" do
+    test "build_field stores greater_than and less_than" do
+      field = JSONSchema.build_field(:score, :number, greater_than: 0, less_than: 100)
+      assert field.greater_than == 0
+      assert field.less_than == 100
+    end
+
+    test "greater_than: rejects equal values, accepts strictly greater" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:score, :number, required: true, greater_than: 0)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"score" => 0})
+      assert Enum.any?(errors, &String.contains?(&1, "must be greater than 0"))
+
+      assert {:error, _} = JSONSchema.validate(schema, %{"score" => -1})
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"score" => 1})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"score" => 0.001})
+    end
+
+    test "less_than: rejects equal values, accepts strictly less" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:score, :number, required: true, less_than: 10)
+        ])
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"score" => 10})
+      assert Enum.any?(errors, &String.contains?(&1, "must be less than 10"))
+
+      assert {:error, _} = JSONSchema.validate(schema, %{"score" => 11})
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"score" => 9})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"score" => 9.999})
+    end
+
+    test "JSON Schema emits exclusiveMinimum and exclusiveMaximum" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:score, :number, greater_than: 0, less_than: 100)
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.score.exclusiveMinimum == 0
+      assert json.properties.score.exclusiveMaximum == 100
+    end
+  end
+
+  describe "exact length (length:)" do
+    test "build_field stores length" do
+      field = JSONSchema.build_field(:code, :string, length: 5)
+      assert field.length == 5
+    end
+
+    test "length: validates exact string length" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:code, :string, required: true, length: 5)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"code" => "abcde"})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"code" => "abcd"})
+      assert Enum.any?(errors, &String.contains?(&1, "length must be exactly 5"))
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"code" => "abcdef"})
+      assert Enum.any?(errors, &String.contains?(&1, "length must be exactly 5"))
+    end
+
+    test "length: validates exact array length" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:coords, {:array, :number}, required: true, length: 3)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"coords" => [1.0, 2.0, 3.0]})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"coords" => [1.0, 2.0]})
+      assert Enum.any?(errors, &String.contains?(&1, "length must be exactly 3"))
+    end
+
+    test "JSON Schema emits minLength==maxLength for strings" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:code, :string, length: 5)
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.code.minLength == 5
+      assert json.properties.code.maxLength == 5
+    end
+
+    test "JSON Schema emits minItems==maxItems for arrays" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:coords, {:array, :number}, length: 3)
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.coords.minItems == 3
+      assert json.properties.coords.maxItems == 3
+    end
+  end
+
+  describe "array length validation (min_length/max_length on arrays)" do
+    test "min_length: on arrays validates array length" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:tags, {:array, :string}, required: true, min_length: 2)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"tags" => ["a", "b"]})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"tags" => ["a", "b", "c"]})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"tags" => ["a"]})
+      assert Enum.any?(errors, &String.contains?(&1, "length"))
+    end
+
+    test "max_length: on arrays validates array length" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:tags, {:array, :string}, required: true, max_length: 3)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"tags" => ["a", "b", "c"]})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"tags" => ["a", "b", "c", "d"]})
+      assert Enum.any?(errors, &String.contains?(&1, "length"))
+    end
+
+    test "JSON Schema emits minItems/maxItems for arrays" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:tags, {:array, :string}, min_length: 1, max_length: 10)
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.tags.minItems == 1
+      assert json.properties.tags.maxItems == 10
+      # Should NOT have minLength/maxLength (those are for strings)
+      refute Map.has_key?(json.properties.tags, :minLength)
+      refute Map.has_key?(json.properties.tags, :maxLength)
+    end
+  end
+
+  describe "exclusion:" do
+    test "build_field stores exclusion" do
+      field = JSONSchema.build_field(:role, :string, exclusion: ["admin", "superuser"])
+      assert field.exclusion == ["admin", "superuser"]
+    end
+
+    test "exclusion: rejects values in the exclusion list" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:role, :string,
+            required: true,
+            exclusion: ["admin", "superuser"]
+          )
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"role" => "user"})
+      assert {:ok, _} = JSONSchema.validate(schema, %{"role" => "editor"})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"role" => "admin"})
+      assert Enum.any?(errors, &String.contains?(&1, "must not be one of"))
+
+      assert {:error, _} = JSONSchema.validate(schema, %{"role" => "superuser"})
+    end
+
+    test "exclusion: is NOT emitted in JSON Schema output" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:role, :string, exclusion: ["admin"])
+        ])
+
+      json = JSONSchema.to_json(schema)
+      refute Map.has_key?(json.properties.role, :exclusion)
+    end
+  end
+
+  describe "format: ~r// with validation" do
+    test "format: ~r// validates string values" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:email, :string, required: true, format: ~r/@/)
+        ])
+
+      assert {:ok, _} = JSONSchema.validate(schema, %{"email" => "user@example.com"})
+
+      assert {:error, errors} = JSONSchema.validate(schema, %{"email" => "nope"})
+      assert Enum.any?(errors, &String.contains?(&1, "pattern"))
+    end
+
+    test "format: ~r// emits pattern in JSON Schema" do
+      schema =
+        JSONSchema.build_from_fields([
+          JSONSchema.build_field(:email, :string, format: ~r/@/)
+        ])
+
+      json = JSONSchema.to_json(schema)
+      assert json.properties.email.pattern == "@"
+    end
+  end
+end

--- a/test/support/app/mcp/router.ex
+++ b/test/support/app/mcp/router.ex
@@ -55,6 +55,29 @@ defmodule Test.MCP.Router do
     {:reply, Resource.list(page, next_cursor), session}
   end
 
+  tool :validated_echo_tool, description: "Echo with validation" do
+    field :message, :string, required: true
+    field :count, :integer, default: 1
+    field :tags, {:array, :string}
+  end
+
+  tool :validated_nested_tool, description: "Nested validation tool" do
+    field :query, :string, required: true
+
+    field :filters, :map do
+      field :category, :string
+      field :min_price, :number
+    end
+  end
+
+  tool :validated_custom_tool, description: "Custom validator tool" do
+    field :query, :string,
+      required: true,
+      validate: fn value ->
+        if String.length(value) >= 3, do: :ok, else: {:error, "must be at least 3 characters"}
+      end
+  end
+
   tool :explode_tool, description: "Always throws an exception"
   tool :binary_tool, mime_type: "image/png", description: "A binary tool"
   tool :audio_tool, description: "An audio tool"
@@ -177,6 +200,18 @@ defmodule Test.MCP.Router do
   end
 
   def explode_tool(_params, _session), do: raise("boom")
+
+  def validated_echo_tool(params, session) do
+    {:reply, Phantom.Tool.text(params), session}
+  end
+
+  def validated_nested_tool(params, session) do
+    {:reply, Phantom.Tool.text(params), session}
+  end
+
+  def validated_custom_tool(params, session) do
+    {:reply, Phantom.Tool.text(params), session}
+  end
 
   def echo_tool(params, session) do
     {:reply, Phantom.Tool.text(params["message"] || ""), session}


### PR DESCRIPTION
This adds an Ecto-like syntax for defining input schemas on tools.

```elixir
@description """
Search with filters
"""
tool :nested_search_tool do
  field :query, :string, required: true

  field :filters, :map, required: true do
    field :category, :string
    field :min_price, :number
  end
end
```