### PR TITLE
fix: remove runorcomp

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,7 @@ defmodule Phantom.MixProject do
   def project do
     [
       aliases: aliases(),
-      compilers: Mix.compilers() ++ [:runorcomp],
-      elixirc_options: [tracers: [Runorcomp.Tracer]],
+      compilers: Mix.compilers(),
       app: :phantom_mcp,
       description: "Elixir MCP (Model Context Protocol) server library with Plug",
       deps: deps(),
@@ -51,7 +50,6 @@ defmodule Phantom.MixProject do
       {:ex_doc, "~> 0.31", only: :dev, warn_if_outdated: true, runtime: false},
       {:tidewave, "~> 0.5", only: [:test], warn_if_outdated: true},
       {:exsync, "~> 0.4", only: [:test]},
-      {:runorcomp, "~> 0.1", only: [:dev], runtime: false},
       {:bandit, "~> 1.0", only: [:test]}
     ]
   end


### PR DESCRIPTION
Unclear to me why, but its failing to load at compile-time.

```
mix compile
==> phantom_mcp
Compiling 21 files (.ex)

== Compilation error in file lib/phantom.ex ==
** (UndefinedFunctionError) function Runorcomp.Tracer.trace/2 is undefined (module Runorcomp.Tracer is not available)
    Runorcomp.Tracer.trace(:start, #Macro.Env<aliases: [], context: nil, context_modules: [], file: "/Users/davidlucia/dev/tvlabs/platform/sauron/deps/phantom_mcp/lib/phantom.ex", function: nil, functions: [{Kernel, [!=: 2, !==: 2, *: 2, **: 2, +: 1, +: 2, ++: 2, -: 1, -: 2, --: 2, /: 2, <: 2, <=: 2, ==: 2, ===: 2, =~: 2, >: 2, >=: 2, abs: 1, apply: 2, apply: 3, binary_part: 3, binary_slice: 2, binary_slice: 3, bit_size: 1, byte_size: 1, ceil: 1, div: 2, elem: 2, exit: 1, floor: 1, function_exported?: 3, get_and_update_in: 3, get_in: 2, hd: 1, inspect: 1, inspect: 2, is_atom: 1, is_binary: 1, is_bitstring: 1, is_boolean: 1, is_float: 1, is_function: 1, is_function: 2, is_integer: 1, is_list: 1, is_map: 1, is_map_key: 2, is_number: 1, is_pid: 1, is_port: 1, is_reference: 1, is_tuple: 1, length: 1, macro_exported?: 3, make_ref: 0, map_size: 1, max: 2, min: 2, node: 0, node: 1, not: 1, pop_in: 2, put_elem: 3, put_in: 3, rem: 2, round: 1, self: 0, send: 2, spawn: 1, spawn: 3, spawn_link: 1, spawn_link: 3, spawn_monitor: 1, spawn_monitor: 3, struct: 1, struct: 2, struct!: 1, struct!: 2, throw: 1, tl: 1, to_timeout: 1, trunc: 1, tuple_size: 1, update_in: 3]}], lexical_tracker: #PID<0.267.0>, line: 1, macro_aliases: [], macros: [{Kernel, ...}], ...>)
    (elixir 1.19.5) src/elixir_env.erl:34: :elixir_env."-trace/2-lc$^0/1-0-"/3
    (elixir 1.19.5) src/elixir_env.erl:34: :elixir_env.trace/2
    (elixir 1.19.5) lib/kernel/parallel_compiler.ex:529: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
could not compile dependency :phantom_mcp, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile phantom_mcp --force", update it with "mix deps.update phantom_mcp" or clean it with "mix deps.clean phantom_mcp"
```