### PR TITLE
fix: handle elicitation failures

### DIFF
--- a/lib/phantom/router.ex
+++ b/lib/phantom/router.ex
@@ -129,12 +129,6 @@ defmodule Phantom.Router do
     quote location: :keep, generated: true do
       @behaviour Phantom.Router
 
-      require Phantom.ClientLogger
-      require Phantom.Prompt
-      require Phantom.Resource
-      require Phantom.Session
-      require Phantom.Tool
-
       import Phantom.Router,
         only: [
           tool: 2,
@@ -146,6 +140,12 @@ defmodule Phantom.Router do
           prompt: 2,
           prompt: 3
         ]
+
+      require Phantom.ClientLogger
+      require Phantom.Prompt
+      require Phantom.Resource
+      require Phantom.Session
+      require Phantom.Tool
 
       @before_compile Phantom.Router
       @after_verify Phantom.Router
@@ -171,7 +171,7 @@ defmodule Phantom.Router do
           case @icons do
             nil -> nil
             [] -> nil
-            icons -> Enum.map(icons, &Phantom.Icon.build/1) |> Phantom.Icon.to_json_list()
+            icons -> icons |> Enum.map(&Phantom.Icon.build/1) |> Phantom.Icon.to_json_list()
           end
 
         {:ok,
@@ -372,12 +372,7 @@ defmodule Phantom.Router do
         Phantom.Router.list_tools(__MODULE__, session, params["cursor"])
       end
 
-      def dispatch_method(
-            "logging/setLevel",
-            %{"level" => log_level},
-            request,
-            session
-          ) do
+      def dispatch_method("logging/setLevel", %{"level" => log_level}, request, session) do
         case Session.set_log_level(session, request, log_level) do
           :ok -> {:reply, %{}, session}
           :error -> {:error, Request.closed(), session}
@@ -489,14 +484,18 @@ defmodule Phantom.Router do
         {:reply, nil, session}
       end
 
-      def dispatch_method(
-            _method,
-            _params,
-            %{id: request_id, response: %{} = response},
-            session
-          )
+      def dispatch_method(_method, _params, %{id: request_id, response: %{} = response}, session)
           when is_binary(request_id) do
-        case Phantom.Tracker.get_session(session) do
+        require Logger
+
+        session_pid = Phantom.Tracker.get_session(session)
+
+        Logger.debug(
+          "Routing elicitation response #{request_id} for session #{session.id}: " <>
+            "tracked_pid=#{inspect(session_pid)} response=#{inspect(response)}"
+        )
+
+        case session_pid do
           nil -> :ok
           pid -> GenServer.cast(pid, {:elicitation_response, request_id, response})
         end

--- a/lib/phantom/session.ex
+++ b/lib/phantom/session.ex
@@ -55,7 +55,9 @@ defmodule Phantom.Session do
           transport_pid: pid()
         }
 
-  @elicitation_timeout :timer.minutes(5)
+  require Logger
+
+  @elicitation_timeout to_timeout(minute: 5)
 
   @spec new(String.t() | nil, Keyword.t() | map) :: t()
   @doc """
@@ -126,6 +128,7 @@ defmodule Phantom.Session do
             GenServer.call(pid, {:elicit, elicitation}, timeout)
           catch
             :exit, {:timeout, _} -> :timeout
+            :exit, _reason -> :error
           end
       end
     end)
@@ -415,9 +418,15 @@ defmodule Phantom.Session do
   def handle_cast({:elicitation_response, request_id, response}, state) do
     case pop_in(state, [:elicitation_callers, request_id]) do
       {nil, state} ->
+        Logger.warning(
+          "Elicitation response #{request_id} has no matching caller. " <>
+            "Known callers: #{inspect(Map.keys(state[:elicitation_callers] || %{}))}"
+        )
+
         {:noreply, state}
 
       {from, state} ->
+        Logger.debug("Elicitation response #{request_id} matched, replying to caller")
         GenServer.reply(from, {:ok, response})
         {:noreply, state}
     end
@@ -602,23 +611,21 @@ defmodule Phantom.Session do
     {:noreply, state}
   end
 
+  # Notifications have no id; dispatch but don't write a response
   defp dispatch_stdio_request(%Request{id: nil} = request, state) do
-    # Notifications have no id; dispatch but don't write a response
-    try do
-      case state.session.router.dispatch_method([
-             request.method,
-             request.params,
-             request,
-             state.session
-           ]) do
-        {:reply, _result, %__MODULE__{} = session} -> put_in(state.session, session)
-        {:noreply, %__MODULE__{} = session} -> put_in(state.session, session)
-        {:error, _error, %__MODULE__{} = session} -> put_in(state.session, session)
-        _ -> state
-      end
-    rescue
+    case state.session.router.dispatch_method([
+           request.method,
+           request.params,
+           request,
+           state.session
+         ]) do
+      {:reply, _result, %__MODULE__{} = session} -> put_in(state.session, session)
+      {:noreply, %__MODULE__{} = session} -> put_in(state.session, session)
+      {:error, _error, %__MODULE__{} = session} -> put_in(state.session, session)
       _ -> state
     end
+  rescue
+    _ -> state
   end
 
   defp dispatch_stdio_request(request, state) do


### PR DESCRIPTION
After playing with elicitation a bit, I ran into some issues where Claude Code would just hang indefinitely. This PR has a fix and some logging improvements for easier debugging

1. Catch all exits in Session.elicit/3, not just timeouts

When the tracked session PID dies mid-elicitation (e.g., SSE stream closed by client), GenServer.call exits with {:noproc, ...} or {:shutdown, ...}. Previously only {:timeout, _} was caught, so any other exit crashed the tool call POST process — leaving the client hanging with no response. Now returns :error so callers can handle it gracefully.

2. Diagnostic logging for elicitation response delivery

Added Logger.warning when an elicitation response arrives but has no matching caller in elicitation_callers (indicates the response was routed to the wrong session PID or the caller already died). Added Logger.debug on successful match.

3. Diagnostic logging for elicitation response routing

Added Logger.debug in the response dispatch clause to log the session ID, tracked PID, and response content when routing elicitation results. Helps trace cases where the response POST has a stale/mismatched session ID.