### PR TITLE
fix: avoid AlreadySentError on duplicate SSE GET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Fix `Plug.Conn.AlreadySentError` when a second SSE GET arrives for an
+  existing session. The conflict response (`409 -32000`) is now returned
+  cleanly without attempting to write streaming headers on the sent conn.
+
 ## 0.4.3 (2026-04-03)
 
 - Fix invalid response when client request an invalid resource_uri

--- a/lib/phantom/plug.ex
+++ b/lib/phantom/plug.ex
@@ -278,17 +278,22 @@ defmodule Phantom.Plug do
 
   defp dispatch(%Plug.Conn{method: "GET"} = conn, opts) do
     if opts.pubsub do
-      conn = maybe_track_session_stream(conn)
-      session = conn.private.phantom.session
+      case maybe_track_session_stream(conn) do
+        %Plug.Conn{halted: true} = conn ->
+          conn
 
-      conn
-      |> put_resp_header("mcp-session-id", session.id)
-      |> put_resp_header("cache-control", "no-cache, no-transform")
-      |> put_resp_content_type("text/event-stream")
-      |> put_resp_header("connection", "keep-alive")
-      |> put_resp_header("x-accel-buffering", "no")
-      |> send_chunked(202)
-      |> stream_loop(opts)
+        conn ->
+          session = conn.private.phantom.session
+
+          conn
+          |> put_resp_header("mcp-session-id", session.id)
+          |> put_resp_header("cache-control", "no-cache, no-transform")
+          |> put_resp_content_type("text/event-stream")
+          |> put_resp_header("connection", "keep-alive")
+          |> put_resp_header("x-accel-buffering", "no")
+          |> send_chunked(202)
+          |> stream_loop(opts)
+      end
     else
       conn
       |> put_status(405)

--- a/test/phantom/plug_test.exs
+++ b/test/phantom/plug_test.exs
@@ -299,6 +299,28 @@ defmodule Phantom.PlugTest do
       assert_sse_connected()
       assert Phantom.Tracker.list_sessions() != []
     end
+
+    test "second GET on same session returns 409 without raising AlreadySentError" do
+      session_id = "019dd3d8-0000-0000-0000-000000000001"
+
+      :get
+      |> conn("/mcp")
+      |> put_req_header("accept", "text/event-stream")
+      |> call(session_id: session_id)
+
+      assert_sse_connected()
+
+      :get
+      |> conn("/mcp")
+      |> put_req_header("accept", "text/event-stream")
+      |> call(session_id: session_id)
+
+      assert_receive {:conn, conn}
+      assert conn.status == 409
+      error = JSON.decode!(conn.resp_body)
+      assert error["error"]["code"] == -32000
+      assert error["error"]["message"] == "Only one SSE stream is allowed per session"
+    end
   end
 
   test "handles prompt responses" do


### PR DESCRIPTION
Fixes #19.

## Summary

- When a second `GET /mcp` arrives for a session that already has a
  tracked SSE stream, `maybe_track_session_stream/1` correctly responds
  with HTTP 409 and a JSON-RPC `-32000` error and halts the conn.
- However, the `dispatch(%Plug.Conn{method: \"GET\"}, opts)` clause
  was unconditionally calling `put_resp_header` / `send_chunked` on
  the returned conn, which raised `Plug.Conn.AlreadySentError`.
- Branch on `conn.halted` after `maybe_track_session_stream/1` so the
  409 response is returned as-is and SSE setup is skipped.

## Test plan

- [x] New regression test in `test/phantom/plug_test.exs` opens two
      consecutive GETs with the same session id and asserts the
      second returns `status == 409` with `code: -32000` and
      `\"Only one SSE stream is allowed per session\"`.
- [x] Test fails on `main` with `Plug.Conn.AlreadySentError` raised
      at `lib/phantom/plug.ex:285`.
- [x] Test passes with this change.
- [x] Full suite: `mix test` — 201 tests, 0 failures (1 pre-existing
      skip), Elixir 1.19.1 / OTP 28.1.

## Notes for downstream users

While this lands, downstream apps can wrap `Phantom.Plug` and rescue
`Plug.Conn.AlreadySentError` to fall back to a 409 JSON-RPC error
themselves. The wrapper is no longer necessary once this is released.